### PR TITLE
Update ClockSync and time drift handling

### DIFF
--- a/app/src/main/java/com/sendspinlite/ClockSync.kt
+++ b/app/src/main/java/com/sendspinlite/ClockSync.kt
@@ -52,15 +52,18 @@ private data class TimeElement(
  *   - drift:  rate of change of offset (dimensionless, us/us)
  */
 class ClockSync(
-    processStdDev: Double = 0.01,
-    private val forgetFactor: Double = 1.001,
-    private val adaptiveCutoffFraction: Double = 0.75,
-    private val minSamplesBeforeForgetting: Int = 100
+    processStdDev: Double = 0.0,
+    driftProcessStdDev: Double = 1e-11,
+    private val forgetFactor: Double = 2.0,
+    private val adaptiveCutoffFraction: Double = 3.0,
+    private val minSamplesBeforeForgetting: Int = 100,
+    private val maxErrorScale: Double = 0.5
 ) {
     private val tag = "ClockSync"
 
     // Derived process variance (matches reference: self._process_variance = process_std_dev ** 2)
     private val processVariance: Double = processStdDev * processStdDev
+    private val driftProcessVariancePerUs: Double = driftProcessStdDev * driftProcessStdDev
 
     // Kalman filter state -- mirrors reference fields exactly
     private var lastUpdateUs: Long = 0          // _last_update
@@ -212,7 +215,7 @@ class ClockSync(
         val dt: Double = (timeAddedUs - lastUpdateUs).toDouble()
         lastUpdateUs = timeAddedUs
 
-        val updateStdDev: Double = maxError.toDouble()
+        val updateStdDev: Double = maxError.toDouble() * maxErrorScale
         val measurementVariance: Double = updateStdDev * updateStdDev
 
         // --- Multi-sample initialization phase (first 8 measurements) ---
@@ -287,7 +290,7 @@ class ClockSync(
         val dtSquared: Double = dt * dt
 
         // Covariance prediction: P_k|k-1 = F P F^T + Q
-        val driftProcessVariance = 0.0   // Drift assumed stable
+        val driftProcessVariance = dt * driftProcessVariancePerUs
         val newDriftCovariance: Double = driftCovariance + driftProcessVariance
 
         val offsetDriftProcessVariance = 0.0
@@ -373,7 +376,8 @@ class ClockSync(
     fun convertServerToClient(serverTimeUs: Long): Long {
         val te = currentTimeElement
         val baseline = baselineOffsetUs ?: 0L
-        val fullOffset = baseline + te.offset.toLong()
+        val dt = (System.nanoTime() / 1000L - te.lastUpdate).toDouble()
+        val fullOffset = baseline + (te.offset + te.drift * dt).toLong()
         val result = serverTimeUs + fullOffset
         
         if (conversionDebugCount < 3) {
@@ -387,14 +391,14 @@ class ClockSync(
     /** Estimated offset in microseconds (server - client). */
     fun estimatedOffsetUs(): Long = offset.toLong()
 
-    /** Estimated drift (dimensionless). */
-    fun estimatedDriftPpm(): Double = drift
+    /** Estimated drift in parts-per-million. */
+    fun estimatedDriftPpm(): Double = drift * 1_000_000.0
 
     /** Standard deviation of offset estimate in microseconds. */
     fun getOffsetUncertaintyUs(): Long = sqrt(offsetCovariance.coerceAtLeast(0.0)).toLong()
 
-    /** Standard deviation of drift estimate. */
-    fun getDriftUncertaintyPpm(): Double = sqrt(driftCovariance.coerceAtLeast(0.0))
+    /** Standard deviation of drift estimate in parts-per-million. */
+    fun getDriftUncertaintyPpm(): Double = sqrt(driftCovariance.coerceAtLeast(0.0)) * 1_000_000.0
 
     /** True after at least 2 measurements with finite covariance (matches reference is_synchronized). */
     fun hasConverged(): Boolean = updateCount >= 15 && offsetCovariance.isFinite()
@@ -409,7 +413,8 @@ class ClockSync(
     fun getDriftSnr(): Double {
         if (!hasConverged()) return 0.0
         val std = getDriftUncertaintyPpm()
-        return if (std > 0) abs(drift) / std else Double.POSITIVE_INFINITY
+        val driftPpm = estimatedDriftPpm()
+        return if (std > 0) abs(driftPpm) / std else Double.POSITIVE_INFINITY
     }
 
     fun getNetworkConditionQuality(): NetworkQuality {


### PR DESCRIPTION
## Summary

This updates `ClockSync` to better match the Sendspin reference time-filter behavior and fix long-run sync drift during playback.

- Apply drift consistently in both timestamp conversion paths by including drift extrapolation in `convertServerToClient()`.
- Correct drift telemetry units so values reported as ppm are actually converted from the filter’s dimensionless drift state.
- Bring core filter defaults closer to reference settings:
  - `processStdDev = 0.0`
  - `driftProcessStdDev = 1e-11`
  - `forgetFactor = 2.0`
  - `adaptiveCutoffFraction = 3.0`
  - `maxErrorScale = 0.5`
- Add drift process noise in the Kalman prediction step, and use scaled measurement variance (`maxError * maxErrorScale`) in updates.
- Fix drift SNR calculation to compare ppm-to-ppm quantities.

These changes reduce model mismatch with the reference filter and address asymmetry that could cause gradual playback timing divergence.

## Why

Observed client logs showed stable RTT and offset but drift pinned near `0.000ppm`, while playback still required repeated static-delay corrections/restarts.  
The previous implementation applied drift in client→server conversion but not server→client scheduling, and mislabeled drift units, which could mask true drift behavior and contribute to long-run desync.

## Test Plan

- [x] Build and run app with updated `ClockSync`.
- [x] Verify no linter issues in touched files.
- [x] Run 20–30 minute playback session and confirm `AudioSchedule.serverLate` does not trend away over time.
- [x] Verify drift/uncertainty telemetry now shows realistic non-zero ppm values.
- [ ] Compare behavior across two identical clients on same network/server:
  - fewer corrective static delay adjustments
  - reduced audible resync/catch-up events.