### PR TITLE
Fix background ANR risk in port checks

### DIFF
--- a/app/src/main/java/com/sendspinlite/PortChecker.kt
+++ b/app/src/main/java/com/sendspinlite/PortChecker.kt
@@ -1,6 +1,10 @@
 package com.sendspinlite
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.SocketTimeoutException
@@ -8,6 +12,26 @@ import java.net.SocketTimeoutException
 object PortChecker {
     private const val TAG = "PortChecker"
     private const val TIMEOUT_MS = 3000 // 3 second timeout
+
+    internal fun interface SocketConnector {
+        fun connect(
+            host: String,
+            port: Int,
+            timeoutMs: Int,
+        )
+    }
+
+    private object DefaultSocketConnector : SocketConnector {
+        override fun connect(
+            host: String,
+            port: Int,
+            timeoutMs: Int,
+        ) {
+            Socket().use { socket ->
+                socket.connect(InetSocketAddress(host, port), timeoutMs)
+            }
+        }
+    }
 
     sealed class PortCheckResult {
         data class PortOpen(val host: String, val port: Int) : PortCheckResult()
@@ -20,29 +44,48 @@ object PortChecker {
     suspend fun checkPort(
         host: String,
         port: Int,
+    ): PortCheckResult =
+        checkPort(
+            host = host,
+            port = port,
+            ioDispatcher = Dispatchers.IO,
+            socketConnector = DefaultSocketConnector,
+        )
+
+    internal suspend fun checkPort(
+        host: String,
+        port: Int,
+        ioDispatcher: CoroutineDispatcher,
+        socketConnector: SocketConnector,
     ): PortCheckResult {
         return try {
-            val socket = Socket()
-            try {
-                Log.i(TAG, "Checking if port $port is open on $host...")
-                socket.connect(InetSocketAddress(host, port), TIMEOUT_MS)
-                Log.i(TAG, "Port $port is OPEN on $host")
-                PortCheckResult.PortOpen(host, port)
-            } catch (e: SocketTimeoutException) {
-                Log.w(TAG, "Connection timed out to $host:$port (port likely closed)")
-                PortCheckResult.PortClosed(host, port)
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to connect to $host:$port: ${e.message}")
-                PortCheckResult.PortClosed(host, port)
-            } finally {
-                try {
-                    socket.close()
-                } catch (_: Exception) {
-                }
+            withContext(ioDispatcher) {
+                checkPortBlocking(host, port, socketConnector)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "Error checking port $port on $host: ${e.message}", e)
             PortCheckResult.ServerUnreachable(host, port, e.message ?: "Unknown error")
+        }
+    }
+
+    private fun checkPortBlocking(
+        host: String,
+        port: Int,
+        socketConnector: SocketConnector,
+    ): PortCheckResult {
+        return try {
+            Log.i(TAG, "Checking if port $port is open on $host...")
+            socketConnector.connect(host, port, TIMEOUT_MS)
+            Log.i(TAG, "Port $port is OPEN on $host")
+            PortCheckResult.PortOpen(host, port)
+        } catch (e: SocketTimeoutException) {
+            Log.w(TAG, "Connection timed out to $host:$port (port likely closed)")
+            PortCheckResult.PortClosed(host, port)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to connect to $host:$port: ${e.message}")
+            PortCheckResult.PortClosed(host, port)
         }
     }
 }

--- a/app/src/test/java/com/sendspinlite/PortCheckerTest.kt
+++ b/app/src/test/java/com/sendspinlite/PortCheckerTest.kt
@@ -42,7 +42,7 @@ class PortCheckerTest {
                         callerThread
                     }
 
-                assertThat(connectorThread.get()).isEqualTo("port-check-io")
+                assertThat(connectorThread.get()).startsWith("port-check-io")
                 assertThat(connectorThread.get()).isNotEqualTo(callerThread)
             } finally {
                 callerDispatcher.close()

--- a/app/src/test/java/com/sendspinlite/PortCheckerTest.kt
+++ b/app/src/test/java/com/sendspinlite/PortCheckerTest.kt
@@ -1,0 +1,52 @@
+package com.sendspinlite
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
+
+class PortCheckerTest {
+    @Test
+    fun checkPort_runsSocketConnectOnIoDispatcher() =
+        runBlocking {
+            val callerDispatcher =
+                Executors.newSingleThreadExecutor { runnable ->
+                    Thread(runnable, "port-check-caller")
+                }.asCoroutineDispatcher()
+            val ioDispatcher =
+                Executors.newSingleThreadExecutor { runnable ->
+                    Thread(runnable, "port-check-io")
+                }.asCoroutineDispatcher()
+
+            try {
+                val connectorThread = AtomicReference<String>()
+                val callerThread =
+                    withContext(callerDispatcher) {
+                        val callerThread = Thread.currentThread().name
+                        val result =
+                            PortChecker.checkPort(
+                                host = "127.0.0.1",
+                                port = 1234,
+                                ioDispatcher = ioDispatcher,
+                                socketConnector =
+                                    PortChecker.SocketConnector { _, _, _ ->
+                                        connectorThread.set(Thread.currentThread().name)
+                                    },
+                            )
+
+                        assertThat(result)
+                            .isInstanceOf(PortChecker.PortCheckResult.PortOpen::class.java)
+                        callerThread
+                    }
+
+                assertThat(connectorThread.get()).isEqualTo("port-check-io")
+                assertThat(connectorThread.get()).isNotEqualTo(callerThread)
+            } finally {
+                callerDispatcher.close()
+                ioDispatcher.close()
+            }
+        }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move blocking port connectivity checks onto an IO dispatcher
- Keep the existing PortChecker public API unchanged
- Add a unit test proving socket connect work runs on the injected IO dispatcher instead of the caller thread

## Context
Sentry issue 119833686 reported a production background ANR on a low-end Android 16 device. The captured stack was an idle main Looper frame, which is common for AppExitInfo ANR snapshots. The most concrete app-side risk found was `SendspinService` launching `SendspinPcmClient.connect()` from a main-dispatcher scope while `PortChecker.checkPort()` performed blocking `Socket.connect()` work inline during background reconnect/boot autostart.

## Verification
- `ANDROID_HOME=/tmp/android-sdk ./gradlew testDebugUnitTest --tests com.sendspinlite.PortCheckerTest`
- `ANDROID_HOME=/tmp/android-sdk ./gradlew testDebugUnitTest ktlintCheck detekt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-616d8846-6ca8-44f6-a186-b703107c1c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-616d8846-6ca8-44f6-a186-b703107c1c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

