### PR TITLE
Fix playback prestart deadlock on poor WiFi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.iml
 .gradle
 /local.properties
+/android-sdk/
+android-sdk/
 /.idea/caches
 /.idea/libraries
 /.idea/modules.xml

--- a/app/src/main/java/com/sendspinlite/AudioIssueReporter.kt
+++ b/app/src/main/java/com/sendspinlite/AudioIssueReporter.kt
@@ -88,6 +88,39 @@ object AudioIssueReporter {
         sb.appendLine("Kalman Errors     : ${uiState.kalmanErrorCount}")
         sb.appendLine()
 
+        sb.appendLine("=== PLAYBACK RECOVERY ===")
+        sb.appendLine("Recovery Status   : ${uiState.playbackRecoveryStatus.ifBlank { "-" }}")
+        sb.appendLine("Audio Output On   : ${uiState.audioOutputStarted}")
+        sb.appendLine("Clock Ready       : ${uiState.clockReadyForPlayback}")
+        sb.appendLine("Force Resync      : ${uiState.forceResyncActive}")
+        sb.appendLine("Discontinuity     : ${uiState.inDiscontinuityRecovery}")
+        sb.appendLine("Late Start Loops  : ${uiState.lateRestartLoops}")
+        sb.appendLine("Server Lateness   : ${uiState.serverLatenessMs} ms")
+        sb.appendLine(
+            "Last Audio Cut    : ${
+                if (uiState.lastAudioCutAgeMs < 0) {
+                    "never"
+                } else {
+                    "${uiState.lastAudioCutAgeMs} ms ago"
+                }
+            }",
+        )
+        sb.appendLine("Last Event        : ${uiState.lastRecoveryEvent.ifBlank { "-" }}")
+        sb.appendLine()
+
+        sb.appendLine("=== PLAYOUT TIMING ===")
+        sb.appendLine("Effective Ahead   : ${uiState.effectiveBufferAheadMs} ms")
+        sb.appendLine("Est. Offset       : ${uiState.estimatedOffsetMs} ms")
+        sb.appendLine("Playout Offset    : ${uiState.playoutOffsetMs} ms")
+        sb.appendLine("Decode Latency    : ${uiState.decodeLatencyMs} ms")
+        sb.appendLine("Network Jitter    : ${uiState.networkJitterMs} ms")
+        sb.appendLine("Clock Updates     : ${uiState.clockUpdateCount}")
+        sb.appendLine()
+
+        sb.appendLine("=== DIAGNOSTIC HINTS ===")
+        sb.appendLine(formatDiagnosticHints(uiState))
+        sb.appendLine()
+
         // Logcat filtered to audio-related tags only.
         // The *:S wildcard silences all other tags so only Sendspin and Android
         // audio subsystem lines are included.
@@ -96,8 +129,10 @@ object AudioIssueReporter {
             val process =
                 Runtime.getRuntime().exec(
                     arrayOf(
-                        "logcat", "-d", "-t", "500",
+                        "logcat", "-d", "-t", "800",
                         "SendspinPcmClient:V",
+                        "ClockSync:V",
+                        "PcmAudioOutput:V",
                         "PlayerViewModel:V",
                         "CrashReportingManager:V",
                         "AudioIssueReporter:V",
@@ -120,6 +155,41 @@ object AudioIssueReporter {
     }
 
     /**
+     * Short, human-readable hints derived from the snapshot (no PII).
+     */
+    internal fun formatDiagnosticHints(uiState: PlayerViewModel.UiState): String {
+        val hints = mutableListOf<String>()
+        if (!uiState.clockReadyForPlayback) {
+            hints.add(
+                "- Clock not ready for playback (converged=${uiState.clockUpdateCount >= 15}, " +
+                    "uncertainty=${uiState.offsetUncertaintyUs / 1000}ms, rtt=${uiState.rttUs / 1000}ms)",
+            )
+        }
+        if (uiState.playbackState == "playing" && !uiState.audioOutputStarted) {
+            hints.add("- Group reports playing but local AudioTrack is not started (prestart/recovery stall)")
+        }
+        if (uiState.queuedChunks >= 60 && uiState.bufferAheadMs < -30) {
+            hints.add("- Large prestart backlog with late head (possible prestart deadlock before fix)")
+        }
+        if (uiState.forceResyncActive) {
+            hints.add("- Force-resync active: expect DIAG force_resync / prestart drops in logcat")
+        }
+        if (uiState.lateDrops > 100) {
+            hints.add("- High late-drop count: clock skew, network loss, or catch-up trimming")
+        }
+        if (uiState.lastAudioCutAgeMs in 0..10_000) {
+            hints.add("- Audio cut occurred recently (check DIAG audio_cut and serverLate)")
+        }
+        if (uiState.serverLatenessMs > 150) {
+            hints.add("- Server lateness above cut threshold (${uiState.serverLatenessMs}ms)")
+        }
+        if (hints.isEmpty()) {
+            hints.add("- No automatic hints; review DIAG lines and buffer/clock sections above")
+        }
+        return hints.joinToString("\n")
+    }
+
+    /**
      * Upload [report] to Sentry as a WARNING-level event and return the Sentry
      * event ID (a UUID string) on success, or `null` if Sentry is not available /
      * not initialised / the upload fails.
@@ -127,7 +197,10 @@ object AudioIssueReporter {
      * The caller is responsible for ensuring that Sentry has been initialised
      * (i.e. crash reporting is enabled) before calling this method.
      */
-    fun uploadToSentry(report: String): String? {
+    fun uploadToSentry(
+        report: String,
+        uiState: PlayerViewModel.UiState? = null,
+    ): String? {
         if (!CrashReportingManager.isCrashReportingAvailable()) return null
         return try {
             val event =
@@ -138,6 +211,14 @@ object AudioIssueReporter {
                     setExtra("app_version", BuildConfig.VERSION_NAME)
                     setExtra("android_version", Build.VERSION.RELEASE)
                     setExtra("device", "${Build.MANUFACTURER} ${Build.MODEL}")
+                    uiState?.let { state ->
+                        setExtra("playback_recovery_status", state.playbackRecoveryStatus)
+                        setExtra("last_recovery_event", state.lastRecoveryEvent)
+                        setExtra("clock_ready", state.clockReadyForPlayback.toString())
+                        setExtra("audio_output_started", state.audioOutputStarted.toString())
+                        setExtra("server_lateness_ms", state.serverLatenessMs.toString())
+                        setExtra("queued_chunks", state.queuedChunks.toString())
+                    }
                 }
             val hint = Hint()
             hint.addAttachment(Attachment(report.toByteArray(Charsets.UTF_8), "audio_report.txt", "text/plain"))

--- a/app/src/main/java/com/sendspinlite/AudioIssueReporter.kt
+++ b/app/src/main/java/com/sendspinlite/AudioIssueReporter.kt
@@ -27,6 +27,7 @@ import java.util.Locale
 object AudioIssueReporter {
     private const val TAG = "AudioIssueReporter"
     private const val REPORT_FILE = "sendspin_audio_report.txt"
+    private const val US_PER_MS = 1000L
 
     /**
      * Build a privacy-redacted diagnostics report focused on the audio pipeline.
@@ -161,26 +162,30 @@ object AudioIssueReporter {
         val hints = mutableListOf<String>()
         if (!uiState.clockReadyForPlayback) {
             hints.add(
-                "- Clock not ready for playback (converged=${uiState.clockUpdateCount >= 15}, " +
-                    "uncertainty=${uiState.offsetUncertaintyUs / 1000}ms, rtt=${uiState.rttUs / 1000}ms)",
+                "- Clock not ready for playback " +
+                    "(converged=${uiState.clockUpdateCount >= PlaybackDiagnostics.CLOCK_CONVERGED_MIN_UPDATES}, " +
+                    "uncertainty=${uiState.offsetUncertaintyUs / US_PER_MS}ms, " +
+                    "rtt=${uiState.rttUs / US_PER_MS}ms)",
             )
         }
         if (uiState.playbackState == "playing" && !uiState.audioOutputStarted) {
             hints.add("- Group reports playing but local AudioTrack is not started (prestart/recovery stall)")
         }
-        if (uiState.queuedChunks >= 60 && uiState.bufferAheadMs < -30) {
+        if (uiState.queuedChunks >= PlaybackDiagnostics.PRESTART_BACKLOG_CHUNK_THRESHOLD &&
+            uiState.bufferAheadMs < PlaybackDiagnostics.PRESTART_LATE_HEAD_MS
+        ) {
             hints.add("- Large prestart backlog with late head (possible prestart deadlock before fix)")
         }
         if (uiState.forceResyncActive) {
             hints.add("- Force-resync active: expect DIAG force_resync / prestart drops in logcat")
         }
-        if (uiState.lateDrops > 100) {
+        if (uiState.lateDrops > PlaybackDiagnostics.HIGH_LATE_DROP_COUNT) {
             hints.add("- High late-drop count: clock skew, network loss, or catch-up trimming")
         }
-        if (uiState.lastAudioCutAgeMs in 0..10_000) {
+        if (uiState.lastAudioCutAgeMs in 0..PlaybackDiagnostics.RECENT_AUDIO_CUT_MAX_AGE_MS) {
             hints.add("- Audio cut occurred recently (check DIAG audio_cut and serverLate)")
         }
-        if (uiState.serverLatenessMs > 150) {
+        if (uiState.serverLatenessMs > PlaybackDiagnostics.AUDIO_CUT_SERVER_LATE_MS) {
             hints.add("- Server lateness above cut threshold (${uiState.serverLatenessMs}ms)")
         }
         if (hints.isEmpty()) {

--- a/app/src/main/java/com/sendspinlite/AudioJitterBuffer.kt
+++ b/app/src/main/java/com/sendspinlite/AudioJitterBuffer.kt
@@ -105,6 +105,31 @@ class AudioJitterBuffer(private val clockSync: ClockSync) {
     }
 
     /**
+     * Drop buffered chunks from the head until the queue head is at least [minAheadMs]
+     * ahead of server "now" (or the queue is empty). Used to escape prestart deadlocks where
+     * a large backlog builds while output is stopped and single-chunk drops cannot catch up.
+     */
+    fun dropUntilHeadAheadAtLeast(
+        nowLocalUs: Long,
+        minAheadMs: Long,
+        maxDrops: Int = maxBufferChunks,
+    ): Int {
+        val nowServerUs = clockSync.convertClientToServer(nowLocalUs)
+        var dropped = 0
+        synchronized(q) {
+            while (dropped < maxDrops) {
+                val head = q.peek() ?: break
+                val aheadMs = (head.serverTimestampUs - nowServerUs) / 1000L
+                if (aheadMs >= minAheadMs) break
+                q.poll()
+                lateDropsCounter.incrementAndGet()
+                dropped++
+            }
+        }
+        return dropped
+    }
+
+    /**
      * Returns the next playable chunk (based on local time mapping),
      * dropping anything that is too late.
      */

--- a/app/src/main/java/com/sendspinlite/MainActivity.kt
+++ b/app/src/main/java/com/sendspinlite/MainActivity.kt
@@ -578,7 +578,7 @@ private fun PlayerScreen(
                                 isCollectingAudioReport = true
                                 scope.launch(Dispatchers.IO) {
                                     val report = AudioIssueReporter.buildReport(ui)
-                                    val eventId = AudioIssueReporter.uploadToSentry(report)
+                                    val eventId = AudioIssueReporter.uploadToSentry(report, ui)
                                     withContext(Dispatchers.Main) {
                                         audioIssueSentryEventId = eventId
                                         isCollectingAudioReport = false
@@ -1008,6 +1008,53 @@ private fun PlayerScreen(
                             color = MaterialTheme.colors.error,
                         )
                     }
+
+                    val recoveryColor =
+                        when (ui.playbackRecoveryStatus) {
+                            PlaybackDiagnostics.STATUS_PLAYING,
+                            PlaybackDiagnostics.STATUS_IDLE,
+                            -> Color.Green
+
+                            PlaybackDiagnostics.STATUS_WAITING_CLOCK,
+                            PlaybackDiagnostics.STATUS_START_BACKOFF,
+                            -> Color(0xFFFFA500)
+
+                            else -> MaterialTheme.colors.error
+                        }
+                    SyncInfoRow(
+                        "Recovery",
+                        ui.playbackRecoveryStatus.ifBlank { "-" },
+                        recoveryColor,
+                    )
+                    if (!ui.audioOutputStarted && ui.playbackState == "playing") {
+                        SyncInfoRow(
+                            "Output",
+                            "not started",
+                            color = MaterialTheme.colors.error,
+                        )
+                    }
+                    if (ui.clockReadyForPlayback.not() && ui.connected) {
+                        SyncInfoRow(
+                            "Clock Gate",
+                            "waiting",
+                            color = Color(0xFFFFA500),
+                        )
+                    }
+                    if (ui.serverLatenessMs > 80) {
+                        SyncInfoRow(
+                            "Server Late",
+                            "${ui.serverLatenessMs}ms",
+                            color = MaterialTheme.colors.error,
+                        )
+                    }
+                    if (ui.lastRecoveryEvent.isNotBlank()) {
+                        Text(
+                            text = "Last: ${ui.lastRecoveryEvent}",
+                            style = MaterialTheme.typography.caption,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
                 }
             }
         }
@@ -1155,6 +1202,18 @@ private fun exportAndShareLogs(
         stringBuilder.append("\nStatistics:\n")
         stringBuilder.append("  Audible Sync Count: ${uiState.audibleSyncCount}\n")
         stringBuilder.append("  Kalman Error Count: ${uiState.kalmanErrorCount}\n")
+        stringBuilder.append("\nPlayback Recovery:\n")
+        stringBuilder.append("  Recovery Status: ${uiState.playbackRecoveryStatus}\n")
+        stringBuilder.append("  Audio Output Started: ${uiState.audioOutputStarted}\n")
+        stringBuilder.append("  Clock Ready: ${uiState.clockReadyForPlayback}\n")
+        stringBuilder.append("  Force Resync: ${uiState.forceResyncActive}\n")
+        stringBuilder.append("  Late Start Loops: ${uiState.lateRestartLoops}\n")
+        stringBuilder.append("  Server Lateness: ${uiState.serverLatenessMs}ms\n")
+        stringBuilder.append("  Effective Buffer Ahead: ${uiState.effectiveBufferAheadMs}ms\n")
+        stringBuilder.append("  Last Recovery Event: ${uiState.lastRecoveryEvent.ifBlank { "-" }}\n")
+        stringBuilder.append("\nDiagnostic Hints:\n")
+        stringBuilder.append(AudioIssueReporter.formatDiagnosticHints(uiState))
+        stringBuilder.append("\n")
         stringBuilder.append("\nVolume:\n")
         stringBuilder.append("  Group Volume: ${uiState.groupVolume}%\n")
         stringBuilder.append("  Group Muted: ${uiState.groupMuted}\n")

--- a/app/src/main/java/com/sendspinlite/MainActivity.kt
+++ b/app/src/main/java/com/sendspinlite/MainActivity.kt
@@ -1040,7 +1040,7 @@ private fun PlayerScreen(
                             color = Color(0xFFFFA500),
                         )
                     }
-                    if (ui.serverLatenessMs > 80) {
+                    if (ui.serverLatenessMs > PlaybackDiagnostics.UI_SERVER_LATENESS_WARN_MS) {
                         SyncInfoRow(
                             "Server Late",
                             "${ui.serverLatenessMs}ms",

--- a/app/src/main/java/com/sendspinlite/PlaybackDiagnostics.kt
+++ b/app/src/main/java/com/sendspinlite/PlaybackDiagnostics.kt
@@ -1,0 +1,21 @@
+package com.sendspinlite
+
+/**
+ * Playback recovery / pipeline status strings used in UI, logs, and audio issue reports.
+ * Keep values stable — they are compared in reports and may appear in Sentry extras.
+ */
+object PlaybackDiagnostics {
+    const val STATUS_IDLE = "idle"
+    const val STATUS_PLAYING = "playing"
+    const val STATUS_WAITING_CLOCK = "waiting_clock_sync"
+    const val STATUS_PRESTART_CATCHUP = "prestart_catchup"
+    const val STATUS_PRESTART_BACKLOG_TRIM = "prestart_backlog_trim"
+    const val STATUS_FORCE_RESYNC_PRESTART = "force_resync_prestart"
+    const val STATUS_START_BACKOFF = "start_backoff"
+    const val STATUS_LATE_START_RECOVERY = "late_start_recovery"
+    const val STATUS_FORCE_RESYNC_RUNTIME = "force_resync_runtime"
+    const val STATUS_CATCHUP_DROP = "catchup_drop"
+    const val STATUS_AUDIO_CUT = "audio_cut"
+    const val STATUS_DISCONTINUITY = "discontinuity_recovery"
+    const val STATUS_UNDERRUN = "buffer_underrun"
+}

--- a/app/src/main/java/com/sendspinlite/PlaybackDiagnostics.kt
+++ b/app/src/main/java/com/sendspinlite/PlaybackDiagnostics.kt
@@ -5,6 +5,15 @@ package com.sendspinlite
  * Keep values stable — they are compared in reports and may appear in Sentry extras.
  */
 object PlaybackDiagnostics {
+    const val CLOCK_CONVERGED_MIN_UPDATES = 15
+    const val PRESTART_BACKLOG_CHUNK_THRESHOLD = 60
+    const val PRESTART_LATE_HEAD_MS = -30L
+    const val HIGH_LATE_DROP_COUNT = 100L
+    const val RECENT_AUDIO_CUT_MAX_AGE_MS = 10_000L
+    const val AUDIO_CUT_SERVER_LATE_MS = 150L
+    const val UI_SERVER_LATENESS_WARN_MS = 80L
+    const val MAX_RECOVERY_EVENT_CHARS = 220
+
     const val STATUS_IDLE = "idle"
     const val STATUS_PLAYING = "playing"
     const val STATUS_WAITING_CLOCK = "waiting_clock_sync"

--- a/app/src/main/java/com/sendspinlite/PlayerViewModel.kt
+++ b/app/src/main/java/com/sendspinlite/PlayerViewModel.kt
@@ -159,6 +159,22 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         // Remote player delay (spec: static_delay_ms, 0-5000ms)
         val staticDelayMs: Long = DEFAULT_STATIC_DELAY_MS,
         val staticDelayMsFromServer: Boolean = false,
+        // Playback pipeline diagnostics (for UI, logs, and audio issue reports)
+        val audioOutputStarted: Boolean = false,
+        val playbackRecoveryStatus: String = PlaybackDiagnostics.STATUS_IDLE,
+        val lastRecoveryEvent: String = "",
+        val clockReadyForPlayback: Boolean = false,
+        val forceResyncActive: Boolean = false,
+        val inDiscontinuityRecovery: Boolean = false,
+        val lateRestartLoops: Int = 0,
+        val effectiveBufferAheadMs: Long = 0,
+        val estimatedOffsetMs: Long = 0,
+        val decodeLatencyMs: Long = 0,
+        val playoutOffsetMs: Long = 0,
+        val networkJitterMs: Long = 0,
+        val clockUpdateCount: Int = 0,
+        val serverLatenessMs: Long = 0,
+        val lastAudioCutAgeMs: Long = -1L,
     )
 
     private val _ui =

--- a/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
+++ b/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
@@ -1093,12 +1093,9 @@ class SendspinPcmClient(
                         if (snapshot.queuedChunks > 0 && snapshot.bufferAheadMs < restartDropTriggerAheadMs) {
                             playbackRecoveryStatus = PlaybackDiagnostics.STATUS_PRESTART_CATCHUP
                             val targetAheadMs = if (forceResyncMode) resyncMinBufferMs else minBufferMs
-                            val dropped =
-                                if (snapshot.queuedChunks >= prestartBacklogChunkThreshold) {
-                                    jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
-                                } else {
-                                    jitter.dropWhileLate(nowUs(), restartKeepWithinUs)
-                                }
+                            // Always trim to the start window; lateness-based drop can leave
+                            // the head outside force-resync (-10..90ms).
+                            val dropped = jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
                             if (dropped > 0) {
                                 val nowMs = System.currentTimeMillis()
                                 if (nowMs - lastRestartCatchupLogMs >= 1000L) {
@@ -1119,12 +1116,7 @@ class SendspinPcmClient(
                             // While recovering from audioserver death, drop stale audio more aggressively
                             // so we rejoin the live timeline quickly.
                             val targetAheadMs = resyncMinBufferMs
-                            val dropped =
-                                if (snap2.queuedChunks >= prestartBacklogChunkThreshold) {
-                                    jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
-                                } else {
-                                    jitter.dropWhileLate(nowUs(), restartKeepWithinUs)
-                                }
+                            val dropped = jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
                             if (dropped > 0) {
                                 val nowMs = System.currentTimeMillis()
                                 if (nowMs - lastForceResyncLogMs >= 1000L) {

--- a/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
+++ b/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
@@ -29,6 +29,8 @@ class SendspinPcmClient(
         private const val KEY_AUDIO_WARMUP_BASELINE_TIMESTAMP_MS = "audio_warmup_baseline_timestamp_ms"
         private const val MAX_CLOCK_UNCERTAINTY_FOR_START_US = 50_000L
         private const val MAX_RTT_FOR_START_US = 2_000_000L
+        private const val RTT_AUDIO_CUT_INFLATE_DIVISOR = 2000L
+        private const val RTT_AUDIO_CUT_INFLATE_MAX_MS = 500L
 
         // Shared OkHttpClient to avoid leaking thread pools and connection pools on reconnect
         private val sharedOkHttp =
@@ -406,7 +408,10 @@ class SendspinPcmClient(
         lastPublishedServerLatenessMs = 0L
         forceResyncMode = false
         forceResyncUntilUs = 0L
+        publishTeardownUi(status)
+    }
 
+    private fun publishTeardownUi(status: String) {
         onUiUpdate {
             it.copy(
                 status = status,
@@ -427,7 +432,6 @@ class SendspinPcmClient(
                 effectiveBufferAheadMs = 0,
                 serverLatenessMs = 0,
                 lastAudioCutAgeMs = -1L,
-                // Clear metadata
                 trackTitle = null,
                 trackArtist = null,
                 albumTitle = null,
@@ -490,7 +494,7 @@ class SendspinPcmClient(
             } else {
                 "$event | $details"
             }
-        lastRecoveryEvent = entry.take(220)
+        lastRecoveryEvent = entry.take(PlaybackDiagnostics.MAX_RECOVERY_EVENT_CHARS)
         Log.i(tag, "DIAG: $entry")
     }
 
@@ -1067,8 +1071,10 @@ class SendspinPcmClient(
                                         lastRestartCatchupLogMs = nowMs
                                         recordRecoveryEvent(
                                             PlaybackDiagnostics.STATUS_WAITING_CLOCK,
-                                            "dropped=$dropped uncertainty=${clock.getOffsetUncertaintyUs() / 1000}ms " +
-                                                "rtt=${clock.getAverageRttUs() / 1000}ms converged=${clock.hasConverged()}",
+                                            "dropped=$dropped " +
+                                                "uncertainty=${clock.getOffsetUncertaintyUs() / 1000}ms " +
+                                                "rtt=${clock.getAverageRttUs() / 1000}ms " +
+                                                "converged=${clock.hasConverged()}",
                                         )
                                     }
                                 }
@@ -1099,7 +1105,8 @@ class SendspinPcmClient(
                                     lastRestartCatchupLogMs = nowMs
                                     recordRecoveryEvent(
                                         PlaybackDiagnostics.STATUS_PRESTART_CATCHUP,
-                                        "dropped=$dropped ahead=${snapshot.bufferAheadMs}ms queued=${snapshot.queuedChunks}",
+                                        "dropped=$dropped ahead=${snapshot.bufferAheadMs}ms " +
+                                            "queued=${snapshot.queuedChunks}",
                                     )
                                 }
                             }
@@ -1378,7 +1385,9 @@ class SendspinPcmClient(
                         if (startupCutGraceActive) (audioOutOfSyncThresholdMs + 120L) else audioOutOfSyncThresholdMs
                     val rttInflatedThresholdMs =
                         if (clock.getAverageRttUs() > MAX_RTT_FOR_START_US) {
-                            effectiveOutOfSyncThresholdMs + (clock.getAverageRttUs() / 2000L).coerceAtMost(500L)
+                            effectiveOutOfSyncThresholdMs +
+                                (clock.getAverageRttUs() / RTT_AUDIO_CUT_INFLATE_DIVISOR)
+                                    .coerceAtMost(RTT_AUDIO_CUT_INFLATE_MAX_MS)
                         } else {
                             effectiveOutOfSyncThresholdMs
                         }

--- a/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
+++ b/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
@@ -1017,7 +1017,6 @@ class SendspinPcmClient(
 
                 // NEW: if output is stopped and the queue head is very late, we must drop until near-now,
                 // otherwise bufferAheadMs stays negative and we never restart (queue grows forever).
-                val restartKeepWithinUs = 20_000L // bring head within ~20ms late before (re)start
                 val restartDropTriggerAheadMs = -60L // pre-drop once head is meaningfully late
                 val restartMinAheadMs = -30L // consider late-start recovery once head is below this
                 val restartMinQueued =

--- a/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
+++ b/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
@@ -27,6 +27,8 @@ class SendspinPcmClient(
         private const val KEY_AUDIO_WARMUP_BASELINE_LATENCY_US = "audio_warmup_baseline_latency_us"
         private const val KEY_AUDIO_WARMUP_BASELINE_FORMAT = "audio_warmup_baseline_format"
         private const val KEY_AUDIO_WARMUP_BASELINE_TIMESTAMP_MS = "audio_warmup_baseline_timestamp_ms"
+        private const val MAX_CLOCK_UNCERTAINTY_FOR_START_US = 50_000L
+        private const val MAX_RTT_FOR_START_US = 2_000_000L
 
         // Shared OkHttpClient to avoid leaking thread pools and connection pools on reconnect
         private val sharedOkHttp =
@@ -196,6 +198,15 @@ class SendspinPcmClient(
     private var forceResyncMode: Boolean = false
     private var forceResyncUntilUs: Long = 0L
     private var lastForceResyncLogMs: Long = 0L
+
+    @Volatile
+    private var playbackRecoveryStatus: String = PlaybackDiagnostics.STATUS_IDLE
+
+    @Volatile
+    private var lastRecoveryEvent: String = ""
+
+    @Volatile
+    private var lastPublishedServerLatenessMs: Long = 0L
 
     // Audio cut and resync configuration for handling late drops
     // When audio falls too far behind after packet loss, cut and resync instead of relying on slow playback speed
@@ -390,6 +401,11 @@ class SendspinPcmClient(
         lastChunkServerTimestampUs = Long.MIN_VALUE
         inDiscontinuityMode = false
         audioScheduleDebugCount = 0
+        playbackRecoveryStatus = PlaybackDiagnostics.STATUS_IDLE
+        lastRecoveryEvent = ""
+        lastPublishedServerLatenessMs = 0L
+        forceResyncMode = false
+        forceResyncUntilUs = 0L
 
         onUiUpdate {
             it.copy(
@@ -401,6 +417,16 @@ class SendspinPcmClient(
                 groupName = "",
                 queuedChunks = 0,
                 bufferAheadMs = 0,
+                audioOutputStarted = false,
+                playbackRecoveryStatus = PlaybackDiagnostics.STATUS_IDLE,
+                lastRecoveryEvent = "",
+                clockReadyForPlayback = false,
+                forceResyncActive = false,
+                inDiscontinuityRecovery = false,
+                lateRestartLoops = 0,
+                effectiveBufferAheadMs = 0,
+                serverLatenessMs = 0,
+                lastAudioCutAgeMs = -1L,
                 // Clear metadata
                 trackTitle = null,
                 trackArtist = null,
@@ -452,6 +478,76 @@ class SendspinPcmClient(
 
         // Calculate moving average
         decodeLatencyUs = decodeLatencySamples.average().toLong()
+    }
+
+    private fun recordRecoveryEvent(
+        event: String,
+        details: String,
+    ) {
+        val entry =
+            if (details.isBlank()) {
+                event
+            } else {
+                "$event | $details"
+            }
+        lastRecoveryEvent = entry.take(220)
+        Log.i(tag, "DIAG: $entry")
+    }
+
+    private fun isClockReadyForPlayback(): Boolean =
+        clock.hasConverged() &&
+            clock.getOffsetUncertaintyUs() <= MAX_CLOCK_UNCERTAINTY_FOR_START_US &&
+            clock.getAverageRttUs() <= MAX_RTT_FOR_START_US
+
+    private fun publishPlaybackDiagnostics(
+        snapshot: AudioJitterBuffer.Snapshot,
+        recoveryStatus: String,
+        clockReady: Boolean,
+        lateRestartLoops: Int = 0,
+        serverLatenessMs: Long? = null,
+    ) {
+        playbackRecoveryStatus = recoveryStatus
+        val effectiveAheadMs = snapshot.bufferAheadMs + (playoutOffsetUs / 1000L)
+        val cutAgeMs =
+            if (lastAudioCutMs <= 0L) {
+                -1L
+            } else {
+                (System.currentTimeMillis() - lastAudioCutMs).coerceAtLeast(0L)
+            }
+        val latenessMs =
+            serverLatenessMs ?: lastPublishedServerLatenessMs
+        if (serverLatenessMs != null) {
+            lastPublishedServerLatenessMs = serverLatenessMs
+        }
+        throttledUiUpdate {
+            it.copy(
+                audioOutputStarted = output.isStarted(),
+                playbackRecoveryStatus = recoveryStatus,
+                lastRecoveryEvent = lastRecoveryEvent,
+                clockReadyForPlayback = clockReady,
+                forceResyncActive = forceResyncMode,
+                inDiscontinuityRecovery = inDiscontinuityMode,
+                lateRestartLoops = lateRestartLoops,
+                effectiveBufferAheadMs = effectiveAheadMs,
+                estimatedOffsetMs = clock.estimatedOffsetUs() / 1000L,
+                decodeLatencyMs = decodeLatencyUs / 1000L,
+                playoutOffsetMs = (playoutOffsetUs + playoutOffsetAdjustmentUs) / 1000L,
+                networkJitterMs = clock.getEstimatedNetworkJitterUs() / 1000L,
+                clockUpdateCount = clock.getUpdateCount(),
+                driftUncertaintyPpm = clock.getDriftUncertaintyPpm(),
+                driftSnr = clock.getDriftSnr(),
+                serverLatenessMs = latenessMs,
+                lastAudioCutAgeMs = cutAgeMs,
+                queuedChunks = snapshot.queuedChunks,
+                bufferAheadMs = snapshot.bufferAheadMs,
+                lateDrops = snapshot.lateDrops,
+                offsetUncertaintyUs = clock.getOffsetUncertaintyUs(),
+                driftPpm = clock.estimatedDriftPpm(),
+                rttUs = clock.getAverageRttUs(),
+                audibleSyncCount = audibleSyncCount,
+                kalmanErrorCount = clock.getKalmanErrorCount(),
+            )
+        }
     }
 
     private fun throttledUiUpdate(block: (PlayerViewModel.UiState) -> PlayerViewModel.UiState) {
@@ -663,12 +759,13 @@ class SendspinPcmClient(
                     // Signal that stats loop is alive
                     lastStatsHeartbeatMs = System.currentTimeMillis()
 
-                    // Update UI with clock sync details - runs every 1 second for responsive updates
+                    publishPlaybackDiagnostics(
+                        snapshot = snapshot,
+                        recoveryStatus = playbackRecoveryStatus,
+                        clockReady = isClockReadyForPlayback(),
+                    )
                     throttledUiUpdate {
                         it.copy(
-                            offsetUncertaintyUs = clock.getOffsetUncertaintyUs(),
-                            driftPpm = clock.estimatedDriftPpm(),
-                            rttUs = clock.getAverageRttUs(),
                             networkQuality = clock.getNetworkConditionQuality().toString(),
                             stability = clock.getClockStability().toString(),
                             connectionType = getConnectionType(),
@@ -923,8 +1020,6 @@ class SendspinPcmClient(
                     4 // allow recovery to begin sooner on constrained devices
                 val forceStartAfterLoops = 80 // ~0.8s with 10ms retry delay
                 val prestartBacklogChunkThreshold = 60 // trim aggressively when prestart queue grows
-                val maxClockUncertaintyForStartUs = 50_000L // 50ms — do not start while sync is unreliable
-                val maxRttForStartUs = 2_000_000L // 2s RTT — matches extreme WiFi spikes in field reports
 
                 var lateRestartLoops = 0
                 var restartBackoffMs = 200L
@@ -936,24 +1031,16 @@ class SendspinPcmClient(
                     // Signal that playback loop is alive
                     lastPlaybackHeartbeatMs = System.currentTimeMillis()
 
-                    // Throttle UI updates to prevent excessive recomposition on low-memory devices
-                    throttledUiUpdate {
-                        it.copy(
-                            queuedChunks = snapshot.queuedChunks,
-                            bufferAheadMs = snapshot.bufferAheadMs,
-                            lateDrops = snapshot.lateDrops,
-                            offsetUncertaintyUs = clock.getOffsetUncertaintyUs(),
-                            driftPpm = clock.estimatedDriftPpm(),
-                            rttUs = clock.getAverageRttUs(),
-                            audibleSyncCount = audibleSyncCount,
-                            kalmanErrorCount = clock.getKalmanErrorCount(),
-                        )
-                    }
-
                     if (!output.isStarted()) {
                         val nowLocalUs = nowUs()
                         if (nextStartAttemptUs > nowLocalUs) {
                             val waitMs = ((nextStartAttemptUs - nowLocalUs) / 1000L).coerceAtLeast(10L)
+                            publishPlaybackDiagnostics(
+                                snapshot = snapshot,
+                                recoveryStatus = PlaybackDiagnostics.STATUS_START_BACKOFF,
+                                clockReady = isClockReadyForPlayback(),
+                                lateRestartLoops = lateRestartLoops,
+                            )
                             delay(waitMs)
                             continue
                         }
@@ -966,12 +1053,10 @@ class SendspinPcmClient(
                         // One-time warmup baseline: run on first launch and after app updates.
                         runAudioWarmupIfNeeded()
 
-                        val clockReadyForPlayback =
-                            clock.hasConverged() &&
-                                clock.getOffsetUncertaintyUs() <= maxClockUncertaintyForStartUs &&
-                                clock.getAverageRttUs() <= maxRttForStartUs
+                        val clockReadyForPlayback = isClockReadyForPlayback()
 
                         if (!clockReadyForPlayback) {
+                            playbackRecoveryStatus = PlaybackDiagnostics.STATUS_WAITING_CLOCK
                             // Poor WiFi can produce multi-second RTT bursts; starting before the
                             // filter converges causes false lateness, audio-cut thrash, and backlog growth.
                             if (snapshot.queuedChunks > 0) {
@@ -980,21 +1065,27 @@ class SendspinPcmClient(
                                     val nowMs = System.currentTimeMillis()
                                     if (nowMs - lastRestartCatchupLogMs >= 1000L) {
                                         lastRestartCatchupLogMs = nowMs
-                                        Log.w(
-                                            tag,
-                                            "waiting for clock sync: dropped=$dropped chunks " +
-                                                "(uncertainty=${clock.getOffsetUncertaintyUs() / 1000}ms " +
-                                                "rtt=${clock.getAverageRttUs() / 1000}ms)",
+                                        recordRecoveryEvent(
+                                            PlaybackDiagnostics.STATUS_WAITING_CLOCK,
+                                            "dropped=$dropped uncertainty=${clock.getOffsetUncertaintyUs() / 1000}ms " +
+                                                "rtt=${clock.getAverageRttUs() / 1000}ms converged=${clock.hasConverged()}",
                                         )
                                     }
                                 }
                             }
+                            publishPlaybackDiagnostics(
+                                snapshot = jitter.snapshot(),
+                                recoveryStatus = PlaybackDiagnostics.STATUS_WAITING_CLOCK,
+                                clockReady = false,
+                                lateRestartLoops = lateRestartLoops,
+                            )
                             delay(50)
                             continue
                         }
 
                         // Prevent deadlock when head is late (negative ahead) by dropping late chunks now.
                         if (snapshot.queuedChunks > 0 && snapshot.bufferAheadMs < restartDropTriggerAheadMs) {
+                            playbackRecoveryStatus = PlaybackDiagnostics.STATUS_PRESTART_CATCHUP
                             val targetAheadMs = if (forceResyncMode) resyncMinBufferMs else minBufferMs
                             val dropped =
                                 if (snapshot.queuedChunks >= prestartBacklogChunkThreshold) {
@@ -1006,9 +1097,9 @@ class SendspinPcmClient(
                                 val nowMs = System.currentTimeMillis()
                                 if (nowMs - lastRestartCatchupLogMs >= 1000L) {
                                     lastRestartCatchupLogMs = nowMs
-                                    Log.w(
-                                        tag,
-                                        "restart-catchup: dropped=$dropped head was late (ahead~${snapshot.bufferAheadMs}ms)",
+                                    recordRecoveryEvent(
+                                        PlaybackDiagnostics.STATUS_PRESTART_CATCHUP,
+                                        "dropped=$dropped ahead=${snapshot.bufferAheadMs}ms queued=${snapshot.queuedChunks}",
                                     )
                                 }
                             }
@@ -1017,6 +1108,7 @@ class SendspinPcmClient(
                         val snap2 = jitter.snapshot()
 
                         if (forceResyncMode) {
+                            playbackRecoveryStatus = PlaybackDiagnostics.STATUS_FORCE_RESYNC_PRESTART
                             // While recovering from audioserver death, drop stale audio more aggressively
                             // so we rejoin the live timeline quickly.
                             val targetAheadMs = resyncMinBufferMs
@@ -1030,22 +1122,26 @@ class SendspinPcmClient(
                                 val nowMs = System.currentTimeMillis()
                                 if (nowMs - lastForceResyncLogMs >= 1000L) {
                                     lastForceResyncLogMs = nowMs
-                                    Log.w(tag, "force-resync prestart: dropped=$dropped stale chunks")
+                                    recordRecoveryEvent(
+                                        PlaybackDiagnostics.STATUS_FORCE_RESYNC_PRESTART,
+                                        "dropped=$dropped ahead=${snap2.bufferAheadMs}ms queued=${snap2.queuedChunks}",
+                                    )
                                 }
                             }
                         }
 
                         // Large prestart backlog with a nearly-live head: trim to the start window in one pass.
                         if (snap2.queuedChunks >= prestartBacklogChunkThreshold && snap2.bufferAheadMs < restartMinAheadMs) {
+                            playbackRecoveryStatus = PlaybackDiagnostics.STATUS_PRESTART_BACKLOG_TRIM
                             val targetAheadMs = if (forceResyncMode) resyncMinBufferMs else minBufferMs
                             val trimmed = jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
                             if (trimmed > 0) {
                                 val nowMs = System.currentTimeMillis()
                                 if (nowMs - lastRestartCatchupLogMs >= 1000L) {
                                     lastRestartCatchupLogMs = nowMs
-                                    Log.w(
-                                        tag,
-                                        "prestart backlog trim: dropped=$trimmed queued=${snap2.queuedChunks} ahead=${snap2.bufferAheadMs}ms",
+                                    recordRecoveryEvent(
+                                        PlaybackDiagnostics.STATUS_PRESTART_BACKLOG_TRIM,
+                                        "dropped=$trimmed queued=${snap2.queuedChunks} ahead=${snap2.bufferAheadMs}ms",
                                     )
                                 }
                             }
@@ -1092,9 +1188,11 @@ class SendspinPcmClient(
 
                         if (canStart) {
                             if ((forceLateStart || canStartLateRecovery) && !canStartNormally) {
-                                Log.w(
-                                    tag,
-                                    "forcing late-start recovery: ahead=${snapForStart.bufferAheadMs}ms effectiveAhead=${effectiveBufferAheadMs}ms queued=${snapForStart.queuedChunks}",
+                                playbackRecoveryStatus = PlaybackDiagnostics.STATUS_LATE_START_RECOVERY
+                                recordRecoveryEvent(
+                                    PlaybackDiagnostics.STATUS_LATE_START_RECOVERY,
+                                    "ahead=${snapForStart.bufferAheadMs}ms effective=$effectiveBufferAheadMs ms " +
+                                        "queued=${snapForStart.queuedChunks} loops=$lateRestartLoops",
                                 )
                                 // If we're more than 100ms behind on forced late-start, trigger resync to snap to live
                                 // instead of waiting for slow catch-up via playback speed adjustment
@@ -1136,11 +1234,24 @@ class SendspinPcmClient(
                             lateRestartLoops = 0
                             restartBackoffMs = 200L
                             nextStartAttemptUs = 0L
-                            Log.i(
-                                tag,
-                                "Audio output started sr=$sampleRate ch=$channels bd=$bitDepth codec=$codec (buffered=${snapForStart.bufferAheadMs}ms)",
+                            playbackRecoveryStatus = PlaybackDiagnostics.STATUS_PLAYING
+                            recordRecoveryEvent(
+                                PlaybackDiagnostics.STATUS_PLAYING,
+                                "sr=$sampleRate ch=$channels codec=$codec buffered=${snapForStart.bufferAheadMs}ms " +
+                                    "effective=$effectiveBufferAheadMs ms",
+                            )
+                            publishPlaybackDiagnostics(
+                                snapshot = jitter.snapshot(),
+                                recoveryStatus = PlaybackDiagnostics.STATUS_PLAYING,
+                                clockReady = true,
                             )
                         } else {
+                            publishPlaybackDiagnostics(
+                                snapshot = snapForStart,
+                                recoveryStatus = playbackRecoveryStatus,
+                                clockReady = clockReadyForPlayback,
+                                lateRestartLoops = lateRestartLoops,
+                            )
                             delay(10)
                             continue
                         }
@@ -1149,9 +1260,14 @@ class SendspinPcmClient(
                     val chunk = jitter.pollPlayable(nowUs(), lateDropUs)
                     if (chunk == null) {
                         if (jitter.isEmpty()) {
-                            // Throttle error state messages to prevent spam (already throttled in sendClientStateError)
-                            // Removed aggressive silence flushing here to prevent jitter
+                            playbackRecoveryStatus = PlaybackDiagnostics.STATUS_UNDERRUN
                         }
+                        publishPlaybackDiagnostics(
+                            snapshot = jitter.snapshot(),
+                            recoveryStatus = playbackRecoveryStatus,
+                            clockReady = true,
+                            serverLatenessMs = lastPublishedServerLatenessMs,
+                        )
                         delay(2)
                         continue
                     }
@@ -1224,6 +1340,7 @@ class SendspinPcmClient(
                     val serverLatenessMs = -(earlyUs - totalPlayoutOffsetUs) / 1000L
 
                     if (forceResyncMode) {
+                        playbackRecoveryStatus = PlaybackDiagnostics.STATUS_FORCE_RESYNC_RUNTIME
                         // If still late during forced resync, drop to near-live instead of gradually drifting.
                         // Compare against server-time lateness so that devices with large staticDelayMs
                         // or pipeline offset don't spuriously discard all buffered audio.
@@ -1243,7 +1360,10 @@ class SendspinPcmClient(
                         if (serverLatenessMs < 40L || nowUs() >= forceResyncUntilUs) {
                             forceResyncMode = false
                             forceResyncUntilUs = 0L
-                            Log.i(tag, "force-resync complete: serverLate=${serverLatenessMs}ms early=${earlyUs / 1000}ms")
+                            recordRecoveryEvent(
+                                "force_resync_complete",
+                                "serverLate=${serverLatenessMs}ms early=${earlyUs / 1000}ms",
+                            )
                         }
                     }
 
@@ -1257,7 +1377,7 @@ class SendspinPcmClient(
                     val effectiveOutOfSyncThresholdMs =
                         if (startupCutGraceActive) (audioOutOfSyncThresholdMs + 120L) else audioOutOfSyncThresholdMs
                     val rttInflatedThresholdMs =
-                        if (clock.getAverageRttUs() > maxRttForStartUs) {
+                        if (clock.getAverageRttUs() > MAX_RTT_FOR_START_US) {
                             effectiveOutOfSyncThresholdMs + (clock.getAverageRttUs() / 2000L).coerceAtMost(500L)
                         } else {
                             effectiveOutOfSyncThresholdMs
@@ -1266,9 +1386,11 @@ class SendspinPcmClient(
                     if (!forceResyncMode && serverLatenessMs > rttInflatedThresholdMs && timeSinceLastCutMs > 500L) {
                         val snapBeforeCut = jitter.snapshot()
                         val lateDropsCount = snapBeforeCut.lateDrops
-                        Log.w(
-                            tag,
-                            "audio-cut triggered: too far behind (serverLate=${serverLatenessMs}ms, drops=$lateDropsCount, buffer=${snapBeforeCut.queuedChunks} chunks). Cutting audio and resyncing.",
+                        playbackRecoveryStatus = PlaybackDiagnostics.STATUS_AUDIO_CUT
+                        recordRecoveryEvent(
+                            PlaybackDiagnostics.STATUS_AUDIO_CUT,
+                            "serverLate=${serverLatenessMs}ms threshold=$rttInflatedThresholdMs ms " +
+                                "lateDrops=$lateDropsCount queued=${snapBeforeCut.queuedChunks}",
                         )
                         output.stop()
                         outputStartedAtUs = 0L
@@ -1289,6 +1411,7 @@ class SendspinPcmClient(
                     // Use server-time lateness so a large staticDelayMs does not trigger spurious catch-up.
                     val dropLateThresholdMs = dropLateUs / 1000L
                     if (serverLatenessMs > dropLateThresholdMs) {
+                        playbackRecoveryStatus = PlaybackDiagnostics.STATUS_CATCHUP_DROP
                         var dropped = 1
                         val maxDrops = 50 // Prevent unbounded dropping that causes ANR
                         val catchupStart = nowUs()
@@ -1337,13 +1460,28 @@ class SendspinPcmClient(
                         }
                         if (dropped > 1) {
                             audibleSyncCount++
-                            Log.w(
-                                tag,
-                                "catch-up: dropped=$dropped (${(nowUs() - catchupStart) / 1000}ms) playoutOffset=${playoutOffsetUs / 1000}ms adjustment=${playoutOffsetAdjustmentUs / 1000}ms (audibleSyncCount=$audibleSyncCount)",
+                            recordRecoveryEvent(
+                                PlaybackDiagnostics.STATUS_CATCHUP_DROP,
+                                "dropped=$dropped durationMs=${(nowUs() - catchupStart) / 1000} " +
+                                    "serverLate=${serverLatenessMs}ms audibleSyncs=$audibleSyncCount",
                             )
                         }
+                        publishPlaybackDiagnostics(
+                            snapshot = jitter.snapshot(),
+                            recoveryStatus = playbackRecoveryStatus,
+                            clockReady = true,
+                            serverLatenessMs = serverLatenessMs,
+                        )
                         continue
                     }
+
+                    playbackRecoveryStatus = PlaybackDiagnostics.STATUS_PLAYING
+                    publishPlaybackDiagnostics(
+                        snapshot = jitter.snapshot(),
+                        recoveryStatus = PlaybackDiagnostics.STATUS_PLAYING,
+                        clockReady = true,
+                        serverLatenessMs = serverLatenessMs,
+                    )
 
                     // Sleep until we're exactly one pipeline-latency before the intended play time.
                     // This ensures data reaches the speaker at the correct moment regardless of buffer depth.
@@ -1750,6 +1888,11 @@ class SendspinPcmClient(
                         )
                         jitter.clear()
                         inDiscontinuityMode = true
+                        playbackRecoveryStatus = PlaybackDiagnostics.STATUS_DISCONTINUITY
+                        recordRecoveryEvent(
+                            PlaybackDiagnostics.STATUS_DISCONTINUITY,
+                            "jump=${timestampJumpUs / 1000}ms",
+                        )
                         triggerForceResync("stream_discontinuity")
                     }
                 }
@@ -1781,7 +1924,7 @@ class SendspinPcmClient(
         val nowMs = System.currentTimeMillis()
         if (nowMs - lastForceResyncLogMs >= 1000L) {
             lastForceResyncLogMs = nowMs
-            Log.w(tag, "force-resync triggered ($reason), dropped=$dropped")
+            recordRecoveryEvent("force_resync", "reason=$reason dropped=$dropped")
         }
     }
 

--- a/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
+++ b/app/src/main/java/com/sendspinlite/SendspinPcmClient.kt
@@ -922,6 +922,9 @@ class SendspinPcmClient(
                 val restartMinQueued =
                     4 // allow recovery to begin sooner on constrained devices
                 val forceStartAfterLoops = 80 // ~0.8s with 10ms retry delay
+                val prestartBacklogChunkThreshold = 60 // trim aggressively when prestart queue grows
+                val maxClockUncertaintyForStartUs = 50_000L // 50ms — do not start while sync is unreliable
+                val maxRttForStartUs = 2_000_000L // 2s RTT — matches extreme WiFi spikes in field reports
 
                 var lateRestartLoops = 0
                 var restartBackoffMs = 200L
@@ -963,9 +966,42 @@ class SendspinPcmClient(
                         // One-time warmup baseline: run on first launch and after app updates.
                         runAudioWarmupIfNeeded()
 
-                        // NEW: prevent deadlock when head is late (negative ahead) by dropping late chunks now.
+                        val clockReadyForPlayback =
+                            clock.hasConverged() &&
+                                clock.getOffsetUncertaintyUs() <= maxClockUncertaintyForStartUs &&
+                                clock.getAverageRttUs() <= maxRttForStartUs
+
+                        if (!clockReadyForPlayback) {
+                            // Poor WiFi can produce multi-second RTT bursts; starting before the
+                            // filter converges causes false lateness, audio-cut thrash, and backlog growth.
+                            if (snapshot.queuedChunks > 0) {
+                                val dropped = jitter.dropWhileLate(nowUs(), 100_000L)
+                                if (dropped > 0) {
+                                    val nowMs = System.currentTimeMillis()
+                                    if (nowMs - lastRestartCatchupLogMs >= 1000L) {
+                                        lastRestartCatchupLogMs = nowMs
+                                        Log.w(
+                                            tag,
+                                            "waiting for clock sync: dropped=$dropped chunks " +
+                                                "(uncertainty=${clock.getOffsetUncertaintyUs() / 1000}ms " +
+                                                "rtt=${clock.getAverageRttUs() / 1000}ms)",
+                                        )
+                                    }
+                                }
+                            }
+                            delay(50)
+                            continue
+                        }
+
+                        // Prevent deadlock when head is late (negative ahead) by dropping late chunks now.
                         if (snapshot.queuedChunks > 0 && snapshot.bufferAheadMs < restartDropTriggerAheadMs) {
-                            val dropped = jitter.dropWhileLate(nowUs(), restartKeepWithinUs)
+                            val targetAheadMs = if (forceResyncMode) resyncMinBufferMs else minBufferMs
+                            val dropped =
+                                if (snapshot.queuedChunks >= prestartBacklogChunkThreshold) {
+                                    jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
+                                } else {
+                                    jitter.dropWhileLate(nowUs(), restartKeepWithinUs)
+                                }
                             if (dropped > 0) {
                                 val nowMs = System.currentTimeMillis()
                                 if (nowMs - lastRestartCatchupLogMs >= 1000L) {
@@ -983,7 +1019,13 @@ class SendspinPcmClient(
                         if (forceResyncMode) {
                             // While recovering from audioserver death, drop stale audio more aggressively
                             // so we rejoin the live timeline quickly.
-                            val dropped = jitter.dropWhileLate(nowUs(), 40_000L)
+                            val targetAheadMs = resyncMinBufferMs
+                            val dropped =
+                                if (snap2.queuedChunks >= prestartBacklogChunkThreshold) {
+                                    jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
+                                } else {
+                                    jitter.dropWhileLate(nowUs(), restartKeepWithinUs)
+                                }
                             if (dropped > 0) {
                                 val nowMs = System.currentTimeMillis()
                                 if (nowMs - lastForceResyncLogMs >= 1000L) {
@@ -993,40 +1035,66 @@ class SendspinPcmClient(
                             }
                         }
 
+                        // Large prestart backlog with a nearly-live head: trim to the start window in one pass.
+                        if (snap2.queuedChunks >= prestartBacklogChunkThreshold && snap2.bufferAheadMs < restartMinAheadMs) {
+                            val targetAheadMs = if (forceResyncMode) resyncMinBufferMs else minBufferMs
+                            val trimmed = jitter.dropUntilHeadAheadAtLeast(nowUs(), targetAheadMs)
+                            if (trimmed > 0) {
+                                val nowMs = System.currentTimeMillis()
+                                if (nowMs - lastRestartCatchupLogMs >= 1000L) {
+                                    lastRestartCatchupLogMs = nowMs
+                                    Log.w(
+                                        tag,
+                                        "prestart backlog trim: dropped=$trimmed queued=${snap2.queuedChunks} ahead=${snap2.bufferAheadMs}ms",
+                                    )
+                                }
+                            }
+                        }
+
+                        val snapForStart = jitter.snapshot()
+
                         // Calculate effective buffer ahead accounting for playout offset
                         // Chunks will actually be needed playoutOffsetUs in the future (negative offset = sooner)
-                        val effectiveBufferAheadMs = snap2.bufferAheadMs + (playoutOffsetUs / 1000L)
+                        val effectiveBufferAheadMs = snapForStart.bufferAheadMs + (playoutOffsetUs / 1000L)
 
                         val startMinMs = if (forceResyncMode) resyncMinBufferMs else minBufferMs
                         val startMaxMs = if (forceResyncMode) resyncMaxStartAheadMs else maxStartAheadMs
+                        val discontinuityStartMinMs = -80L
+                        val discontinuityStartMaxMs = 250L
+                        val activeStartMinMs =
+                            if (inDiscontinuityMode) discontinuityStartMinMs else startMinMs
+                        val activeStartMaxMs =
+                            if (inDiscontinuityMode) discontinuityStartMaxMs else startMaxMs
 
                         // Start window is based on raw ahead; effective offset is handled in scheduling.
                         val canStartNormally =
-                            snap2.queuedChunks >= restartMinQueued &&
-                                snap2.bufferAheadMs in startMinMs..startMaxMs
+                            snapForStart.queuedChunks >= restartMinQueued &&
+                                snapForStart.bufferAheadMs in activeStartMinMs..activeStartMaxMs
 
                         // Recovery path: when network handoff leaves us perpetually late, don't deadlock.
                         // Start anyway after ~1s of late restarts and let catch-up/drop logic recover.
-                        if (!canStartNormally && snap2.queuedChunks >= restartMinQueued && snap2.bufferAheadMs < restartMinAheadMs) {
+                        if (!canStartNormally && snapForStart.queuedChunks >= restartMinQueued && snapForStart.bufferAheadMs < restartMinAheadMs) {
                             lateRestartLoops++
-                        } else {
+                        } else if (canStartNormally) {
+                            // Do not reset the counter when ahead oscillates around restartMinAheadMs
+                            // while still outside the normal start window — that prevented force-late-start.
                             lateRestartLoops = 0
                         }
 
                         // If we remain late for a while, allow bounded late-start recovery instead of
                         // endless prestart dropping (which can deadlock playback on constrained devices).
                         val canStartLateRecovery =
-                            lateRestartLoops >= 20 && snap2.bufferAheadMs >= -50L
+                            lateRestartLoops >= 20 && snapForStart.bufferAheadMs >= -50L
 
                         val forceLateStart =
-                            lateRestartLoops >= forceStartAfterLoops && snap2.bufferAheadMs >= -40L
+                            lateRestartLoops >= forceStartAfterLoops && snapForStart.bufferAheadMs >= -40L
                         val canStart = canStartNormally || canStartLateRecovery || forceLateStart
 
                         if (canStart) {
                             if ((forceLateStart || canStartLateRecovery) && !canStartNormally) {
                                 Log.w(
                                     tag,
-                                    "forcing late-start recovery: ahead=${snap2.bufferAheadMs}ms effectiveAhead=${effectiveBufferAheadMs}ms queued=${snap2.queuedChunks}",
+                                    "forcing late-start recovery: ahead=${snapForStart.bufferAheadMs}ms effectiveAhead=${effectiveBufferAheadMs}ms queued=${snapForStart.queuedChunks}",
                                 )
                                 // If we're more than 100ms behind on forced late-start, trigger resync to snap to live
                                 // instead of waiting for slow catch-up via playback speed adjustment
@@ -1047,6 +1115,9 @@ class SendspinPcmClient(
                                 continue
                             }
                             outputStartedAtUs = nowUs()
+                            if (inDiscontinuityMode) {
+                                inDiscontinuityMode = false
+                            }
 
                             // Initialize Opus decoder if needed
                             if (codec == "opus") {
@@ -1067,7 +1138,7 @@ class SendspinPcmClient(
                             nextStartAttemptUs = 0L
                             Log.i(
                                 tag,
-                                "Audio output started sr=$sampleRate ch=$channels bd=$bitDepth codec=$codec (buffered=${snap2.bufferAheadMs}ms)",
+                                "Audio output started sr=$sampleRate ch=$channels bd=$bitDepth codec=$codec (buffered=${snapForStart.bufferAheadMs}ms)",
                             )
                         } else {
                             delay(10)
@@ -1185,8 +1256,14 @@ class SendspinPcmClient(
                     val startupCutGraceActive = sinceOutputStartUs < startupCutGraceUs
                     val effectiveOutOfSyncThresholdMs =
                         if (startupCutGraceActive) (audioOutOfSyncThresholdMs + 120L) else audioOutOfSyncThresholdMs
+                    val rttInflatedThresholdMs =
+                        if (clock.getAverageRttUs() > maxRttForStartUs) {
+                            effectiveOutOfSyncThresholdMs + (clock.getAverageRttUs() / 2000L).coerceAtMost(500L)
+                        } else {
+                            effectiveOutOfSyncThresholdMs
+                        }
 
-                    if (!forceResyncMode && serverLatenessMs > effectiveOutOfSyncThresholdMs && timeSinceLastCutMs > 500L) {
+                    if (!forceResyncMode && serverLatenessMs > rttInflatedThresholdMs && timeSinceLastCutMs > 500L) {
                         val snapBeforeCut = jitter.snapshot()
                         val lateDropsCount = snapBeforeCut.lateDrops
                         Log.w(
@@ -1673,6 +1750,7 @@ class SendspinPcmClient(
                         )
                         jitter.clear()
                         inDiscontinuityMode = true
+                        triggerForceResync("stream_discontinuity")
                     }
                 }
 

--- a/app/src/test/java/com/sendspinlite/AudioIssueReporterTest.kt
+++ b/app/src/test/java/com/sendspinlite/AudioIssueReporterTest.kt
@@ -1,0 +1,42 @@
+package com.sendspinlite
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AudioIssueReporterTest {
+    @Test
+    fun buildReport_includesPlaybackRecoveryAndDiagnosticSections() {
+        val uiState =
+            PlayerViewModel.UiState(
+                playbackRecoveryStatus = PlaybackDiagnostics.STATUS_FORCE_RESYNC_PRESTART,
+                audioOutputStarted = false,
+                playbackState = "playing",
+                clockReadyForPlayback = false,
+                lastRecoveryEvent = "force_resync | reason=audio_out_of_sync_late_drop dropped=3",
+                queuedChunks = 120,
+                bufferAheadMs = -40,
+                lateDrops = 200,
+            )
+
+        val report = AudioIssueReporter.buildReport(uiState)
+
+        assertThat(report).contains("=== PLAYBACK RECOVERY ===")
+        assertThat(report).contains("Recovery Status   : force_resync_prestart")
+        assertThat(report).contains("=== PLAYOUT TIMING ===")
+        assertThat(report).contains("=== DIAGNOSTIC HINTS ===")
+        assertThat(report).contains("Clock not ready for playback")
+    }
+
+    @Test
+    fun formatDiagnosticHints_flagsPlayingWithoutLocalOutput() {
+        val hints =
+            AudioIssueReporter.formatDiagnosticHints(
+                PlayerViewModel.UiState(
+                    playbackState = "playing",
+                    audioOutputStarted = false,
+                ),
+            )
+
+        assertThat(hints).contains("AudioTrack is not started")
+    }
+}

--- a/app/src/test/java/com/sendspinlite/AudioJitterBufferTest.kt
+++ b/app/src/test/java/com/sendspinlite/AudioJitterBufferTest.kt
@@ -26,16 +26,17 @@ class AudioJitterBufferTest {
 
     @Test
     fun dropUntilHeadAheadAtLeast_dropsUntilHeadReachesTargetAhead() {
-        buffer.offer(serverTsUs = 1_000, pcm = byteArrayOf(1))
-        buffer.offer(serverTsUs = 2_000, pcm = byteArrayOf(2))
-        buffer.offer(serverTsUs = 3_000, pcm = byteArrayOf(3))
-        buffer.offer(serverTsUs = 5_000, pcm = byteArrayOf(4))
+        // Timestamps are microseconds; values must be large enough that (delta / 1000) is in ms.
+        buffer.offer(serverTsUs = 1_000_000, pcm = byteArrayOf(1))
+        buffer.offer(serverTsUs = 2_000_000, pcm = byteArrayOf(2))
+        buffer.offer(serverTsUs = 3_000_000, pcm = byteArrayOf(3))
+        buffer.offer(serverTsUs = 5_000_000, pcm = byteArrayOf(4))
 
-        val dropped = buffer.dropUntilHeadAheadAtLeast(nowLocalUs = 5_200, minAheadMs = -250L)
+        val dropped = buffer.dropUntilHeadAheadAtLeast(nowLocalUs = 5_200_000, minAheadMs = -250L)
 
         assertThat(dropped).isEqualTo(3)
-        assertThat(buffer.snapshot().bufferAheadMs).isAtLeast(-250L)
         assertThat(buffer.snapshot().queuedChunks).isEqualTo(1)
+        assertThat(buffer.snapshot().headServerUs).isEqualTo(5_000_000L)
     }
 
     @Test

--- a/app/src/test/java/com/sendspinlite/AudioJitterBufferTest.kt
+++ b/app/src/test/java/com/sendspinlite/AudioJitterBufferTest.kt
@@ -25,6 +25,20 @@ class AudioJitterBufferTest {
     }
 
     @Test
+    fun dropUntilHeadAheadAtLeast_dropsUntilHeadReachesTargetAhead() {
+        buffer.offer(serverTsUs = 1_000, pcm = byteArrayOf(1))
+        buffer.offer(serverTsUs = 2_000, pcm = byteArrayOf(2))
+        buffer.offer(serverTsUs = 3_000, pcm = byteArrayOf(3))
+        buffer.offer(serverTsUs = 5_000, pcm = byteArrayOf(4))
+
+        val dropped = buffer.dropUntilHeadAheadAtLeast(nowLocalUs = 5_200, minAheadMs = -250L)
+
+        assertThat(dropped).isEqualTo(3)
+        assertThat(buffer.snapshot().bufferAheadMs).isAtLeast(-250L)
+        assertThat(buffer.snapshot().queuedChunks).isEqualTo(1)
+    }
+
+    @Test
     fun pollPlayable_dropsLateChunksBeforeReturningPlayableChunk() {
         buffer.offer(serverTsUs = 1_000, pcm = byteArrayOf(1))
         buffer.offer(serverTsUs = 2_000, pcm = byteArrayOf(2))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation of two Echo Show 8 audio issue reports (app 1.15, poor WiFi) showed a recurring failure mode: the client falls behind server time, triggers `audio-cut` / `force-resync`, then gets stuck in prestart while chunks keep arriving.

## Root causes

1. **Prestart single-chunk drops** — `dropWhileLate(..., 40ms)` only removes one chunk when the head is barely past the lateness threshold, so incoming audio outpaces trimming and the queue grows (report 2: 239 queued chunks, 1218 late drops).
2. **`lateRestartLoops` reset** — the counter was cleared whenever `bufferAheadMs` rose above `-30ms`, even if still outside the normal start window (`-20..150ms`), so forced late-start (`>= 80` loops) never fired.
3. **Starting before clock sync is usable** — report 1 had RTT up to ~13s and offset uncertainty ±212ms; playback started with an unreliable timeline, causing `restart-catchup`, `audio-cut`, and a 975ms discontinuity.
4. **Stream discontinuity** — buffer was cleared but recovery did not enter force-resync; `inDiscontinuityMode` was never applied.

## Changes

### Playback fixes
- Wait to start `AudioTrack` until the Kalman filter has converged, offset uncertainty ≤ 50ms, and average RTT ≤ 2s; trim stale audio while waiting.
- Add `AudioJitterBuffer.dropUntilHeadAheadAtLeast()` and use it for large prestart backlogs (≥ 60 chunks) and force-resync prestart.
- Only reset `lateRestartLoops` when the normal start window is satisfied.
- Inflate `audio-cut` threshold under very high RTT to reduce thrashing.
- On timestamp discontinuity: `triggerForceResync()` and temporarily widen the start window.

### Diagnostics (audio issue reports & logging)
- New `PlaybackDiagnostics` status constants and `UiState` fields: recovery status, clock gate, force-resync, server lateness, effective buffer ahead, last recovery event, etc.
- Structured **`DIAG:`** log lines for audio-cut, force-resync, catch-up, clock wait, and output start.
- Expanded **audio issue report** sections: `PLAYBACK RECOVERY`, `PLAYOUT TIMING`, `DIAGNOSTIC HINTS`; more logcat tags (`ClockSync`, `PcmAudioOutput`); Sentry extras for recovery status.
- In-app **Audio Sync** card shows recovery status, output/clock gate warnings, and last event.

## Testing

- `AudioJitterBufferTest` — backlog trim
- `AudioIssueReporterTest` — report sections and hints
- Please verify via GitHub Actions (Android SDK required locally)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc508245-8143-4e42-a00d-9e227e4aed8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc508245-8143-4e42-a00d-9e227e4aed8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

