### PR TITLE
fix: stop boot-path OOM caused by leaked per-connection flow collectors

### DIFF
--- a/app/src/main/java/com/sendspinlite/service/SendspinService.kt
+++ b/app/src/main/java/com/sendspinlite/service/SendspinService.kt
@@ -52,6 +52,16 @@ class SendspinService : Service() {
     private var reconnectRetryCount = 0
     // Unlimited reconnection attempts - will keep retrying until manually disconnected
 
+    // Per-connection flow collectors. These MUST be cancelled on every disconnect/reconnect,
+    // otherwise each connect() leaks two coroutines that keep the previous SendspinPcmClient
+    // (and its buffers/audio output) reachable forever. Relying solely on a takeWhile() guard
+    // is insufficient: once `client` is reassigned the old client's flows stop emitting, so the
+    // guard never re-evaluates and the collector stays suspended, pinning the dead client in
+    // memory. Under the boot path (background service, repeated health-recovery reconnects) this
+    // accumulates until the heap is exhausted (OOM).
+    private var diagnosticsJob: Job? = null
+    private var eventsJob: Job? = null
+
     // Connection drop tracking
     private var hasEstablishedConnection = false
     private var dropCountedForCurrentOutage = false
@@ -489,8 +499,10 @@ class SendspinService : Service() {
         client = activeClient
         activeClient.setStaticDelayMs(_uiState.value.staticDelayMs)
 
-        // Listen to client diagnostics Flow
-        scope.launch {
+        // Listen to client diagnostics Flow.
+        // Cancel any previous collector first so a reconnect cannot leak the prior client.
+        diagnosticsJob?.cancel()
+        diagnosticsJob = scope.launch {
             activeClient.diagnostics
                 .takeWhile { client === activeClient }
                 .collect { diag ->
@@ -580,8 +592,10 @@ class SendspinService : Service() {
                 }
         }
 
-        // Listen to server events (Volume, Mute, Delay changes)
-        scope.launch {
+        // Listen to server events (Volume, Mute, Delay changes).
+        // Cancel any previous collector first so a reconnect cannot leak the prior client.
+        eventsJob?.cancel()
+        eventsJob = scope.launch {
             activeClient.events
                 .takeWhile { client === activeClient }
                 .collect { event ->
@@ -682,6 +696,14 @@ class SendspinService : Service() {
         }
 
         client = null
+
+        // Cancel the per-connection flow collectors so they release the client they captured.
+        // Without this they remain suspended on the (now silent) flows and pin the client graph
+        // in memory across reconnects, leaking until the heap is exhausted.
+        diagnosticsJob?.cancel()
+        diagnosticsJob = null
+        eventsJob?.cancel()
+        eventsJob = null
 
         // Stop health monitoring when disconnecting
         stopHealthMonitoring()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Traced the boot-start crash to a coroutine/object leak in `SendspinService`. Every `connect()` launches two long-lived flow collectors that are never cancelled, so each reconnect pins the previous `SendspinPcmClient` graph in memory. The boot path makes this fatal because the service runs unprivileged in the background and reconnects continuously, eventually exhausting the heap (OOM).

## Root cause

In `SendspinService.connect()` two collectors are launched on the **service-scoped** `CoroutineScope` (lifetime = whole service), with no `Job` handle kept:

```kotlin
scope.launch {
    activeClient.diagnostics
        .takeWhile { client === activeClient }
        .collect { diag -> ... }
}
scope.launch {
    activeClient.events
        .takeWhile { client === activeClient }
        .collect { event -> ... }
}
```

`diagnostics` is a `StateFlow` and `events` is a `SharedFlow`; neither ever completes. The `takeWhile { client === activeClient }` guard was added (commit `1e64f88`) to suppress *stale UI writes*, but it does **not** stop the collector after a reconnect:

1. On reconnect, `disconnect()` tears down and **cleans up** the old client (`cleanupResources()` cancels its scope), then a new `activeClient` is created and `client` is reassigned.
2. The old collector is suspended inside `.collect`. Because the old client's flows no longer emit (its scope is cancelled), `takeWhile` is **never re-evaluated**, so the collector never terminates.
3. The suspended collector keeps a reference to the captured `activeClient`, so the entire previous `SendspinPcmClient` (with its `ClockSync`, `AudioJitterBuffer`, `PcmAudioOutput`, protocol handler and the `Service` context) stays reachable forever.

Each reconnect therefore leaks two coroutines plus a full dead client. Over time the heap fills up → `OutOfMemoryError`.

## Why it specifically manifests when started from the BootReceiver

- `BootReceiver` starts the service with `fromBoot = "1"`. On Android 12+ the service uses `startService()` and `startForegroundWithRetry()` deliberately **skips** `startForeground()` for the boot context.
- `startedFromBoot` is set once and never cleared, and `connect()` passes `startedFromBoot || fromBoot` to `startForegroundWithRetry()`, so the service **never** becomes a foreground service for the rest of its lifetime.
- A non-foreground background service is subject to Doze/background throttling. The watchdog/health-monitor loops then repeatedly judge the client unhealthy and fire `recoverService()` / auto-reconnect, so `connect()` runs over and over.

Each of those reconnects leaks another client graph, so the boot path drives the leak hard enough to exhaust the heap and crash — whereas a normal foreground launch (UI present, FGS exemption) rarely reconnects and the leak stays unnoticed.

## Fix

Track the two collectors in `diagnosticsJob` / `eventsJob`, cancel any previous ones before launching new collectors in `connect()`, and cancel them in `disconnect()`. This deterministically releases the previous client on every reconnect instead of relying on the `takeWhile` guard (kept as defence-in-depth against stale emissions).

## Verification

- `./gradlew compileDebugKotlin` — BUILD SUCCESSFUL
- `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (all existing unit tests pass)

Note: the CI/build environment here had no Android SDK pre-installed; it was provisioned manually (cmdline-tools + `platforms;android-36` + `build-tools;36.0.0`) to compile and run tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-838afbb9-2a3a-43e9-b229-7d43a731ad6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-838afbb9-2a3a-43e9-b229-7d43a731ad6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

